### PR TITLE
URL encode space in service_name

### DIFF
--- a/src/slack-notifications/slack-notifications-command.conf
+++ b/src/slack-notifications/slack-notifications-command.conf
@@ -72,7 +72,7 @@ object NotificationCommand "slack-notifications-command" {
     var host_name_with_link = "<" + icinga2_base_url + "/monitoring/host/show?host=" + host_name + "|" + host_display_name + ">"
     var text = "error crafting payload"
     if(service_name != null) {
-        var service_name_with_link = "<" + icinga2_base_url + "/monitoring/service/show?host=" + host_name + "&service=" + service_name + "|" + service_display_name + ">"
+        var service_name_with_link = "<" + icinga2_base_url + "/monitoring/service/show?host=" + host_name + "&service=" + service_name.replace(" ", "%20") + "|" + service_display_name + ">"
         var short_service_output = service_output.substr(0, plugin_output_max_length)
         var service_state_text = " transitioned from state " + service_last_state + " to state " + service_state
         if(service_last_state == service_state) {


### PR DESCRIPTION
Un-encoded space characters in service names cause broken URLs in chat message.